### PR TITLE
feat: ecomm order service can now call out to an API gateway that inv…

### DIFF
--- a/datalayer/src/controllers.ts
+++ b/datalayer/src/controllers.ts
@@ -48,7 +48,20 @@ export const  createOrder = async (req: Request, res: Response) => {
     }
   };
 
-  res.send(message);  
+  const trackOrderFunctionUrl = process.env["TRACK_ORDER_URL"]
+  if (!trackOrderFunctionUrl) {
+    message += " Error: TRACK_ORDER_URL not defined";
+    console.log("TRACK_ORDER_URL not defined")
+  }else{
+    try{
+      await axios.get(trackOrderFunctionUrl);
+    }catch(error){
+      message += " Error: " + trackOrderFunctionUrl + " connection error";
+      console.log(message);
+    }
+  };
+
+  res.send(message);
 }
 
 export const logUserIn = (req: Request, res: Response) => {

--- a/deploy/ecommerce-eks.yaml
+++ b/deploy/ecommerce-eks.yaml
@@ -5,6 +5,34 @@ ecommerce:
   required_secrets:
     - path: attacker.ip
   steps:
+    - name: order-tracker-bucket
+      extension: S3
+      tags: storage
+      description: This step deploy a S3 bucket for tracking orders
+      args:
+        region: !secret aws.region
+        partial_bucket_name: "order-tracker-bucket"
+      outputs:
+        - bucket_name
+    - name: order-tracker-lambda
+      extension: LambdaApiGateway
+      tags: application
+      description: This step deploy a Lambda function for tracking orders
+      helpers:
+        - helper: RunCommand
+          args:
+            commands:
+              - ["mkdir", "lambda"]
+              - ["curl", "-o", "lambda/index.js", "https://raw.githubusercontent.com/lacework-demo/unhackable-ecommerce-app/main/lambda/index.js"]
+      args:
+        region: !secret aws.region
+        bucket_name: !lookup /ecommerce/order-tracker-bucket/outputs/bucket_name
+        lambda_name: "order-tracking-function"
+        lambda_runtime: "nodejs16.x"
+        api_endpoint_name: "trackOrder"
+        lambda_handler: "index.handler"
+      outputs:
+        - lambda_invoke_url
     - name: ecommerce
       extension: Kubectl
       tags: applications
@@ -27,6 +55,7 @@ ecommerce:
         - instance
       args:
         netcat_host_ip: !secret attacker.ip
+        track_order_url: !lookup /ecommerce/order-tracker-lambda/outputs/lambda_invoke_url
         control_plane_url: !lookup /aws-k8s/k8s/outputs/cluster_endpoint
         kubectl_config: !lookup /aws-k8s/k8s/outputs/kubectl_config
         kubectl_config_file: kubectl

--- a/ecommerce.yml
+++ b/ecommerce.yml
@@ -285,6 +285,8 @@ spec:
           value: "3306"
         - name: INVENTORY_SERVICE_URL
           value: "http://ecommerce-inventory:9001/inventory"
+        - name: TRACK_ORDER_URL
+          value: {{ index .  "track_order_url" }}
         ports:
         - containerPort: 9001
           name: ecommerce-order

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,0 +1,26 @@
+var AWS = require('aws-sdk');
+
+async function putObjectToS3(bucket, key, data){
+    var s3 = new AWS.S3();
+    var params = {
+        Bucket : bucket,
+        Key : key,
+        Body : data
+    }
+    await s3.putObject(params, function(err, data) {
+        if (err) console.log(err, err.stack);
+        else     console.log(data);
+    }).promise();;
+}
+
+exports.handler = async (event) => {
+    const rand = (Math.random() + 1).toString(36).substring(7);
+    const file_name = "order_"+rand+".csv"
+    const file_contents = "id\tname\tdata\n"+rand+"\tAA\ttoday"
+    await putObjectToS3(process.env.BUCKET_NAME, file_name, file_contents)
+    const response = {
+        statusCode: 200,
+        body: '{ "status": "orderPlaced" }'
+    };
+    return response;
+};


### PR DESCRIPTION
This PR updates the Ecomm app to make a request to an API Gateway URL that is hooked up to a Lambda function.  Each time an oder is placed the order service make an request to the API gateway.

Notes:
* the ecomm Kubectl manifest file has been updated to pull the order service from my personal docker hub account. This image has been re-built with the the code to make the request to the API Gateway.
* we will need to re-build and push up the order service to the official repo before out next deployment of ecomm
* the deployment will still work even without the tracking service API gateway deployed (for GCP or AKS deployments) as the code check before assuming the gateway exists